### PR TITLE
WEB-1017:  After an error or while an error is present, attempting to use royalties to update a collection does not make the button clickable.

### DIFF
--- a/components/Modal/CollectionModal.tsx
+++ b/components/Modal/CollectionModal.tsx
@@ -297,6 +297,7 @@ const CollectionModal = ({ type, modalProps }: Props): JSX.Element => {
             max={15}
             step={1}
             value={royalties}
+            setFormError={setFormError}
             setValue={setRoyalties}
             placeholder="Royalties"
             tooltip="A percentage of gross revenues derived from the use of an asset sold"


### PR DESCRIPTION
… use royalties to update a collection does not make the button clickable.