### PR TITLE
WEB-1060: Fix long description styling

### DIFF
--- a/components/PageHeader/index.tsx
+++ b/components/PageHeader/index.tsx
@@ -97,7 +97,7 @@ const PageHeader = ({
           maxWidth="684px"
           textAlign="center"
           fontColor="#808080"
-          maxDescriptionLength={190}
+          maxDescriptionLength={183}
         />
       ) : null}
       {buttons}

--- a/components/ReadMoreDescription/ReadMoreDescription.ts
+++ b/components/ReadMoreDescription/ReadMoreDescription.ts
@@ -14,6 +14,8 @@ export const Description = styled.span<DescriptionProps>`
   color: ${({ fontColor }) => fontColor};
   font-size: 14px;
   line-height: 24px;
+  overflow-wrap: break-word;
+  width: 100%;
 `;
 
 export const More = styled.span`

--- a/components/ReadMoreDescription/index.tsx
+++ b/components/ReadMoreDescription/index.tsx
@@ -29,6 +29,11 @@ const ReadMoreDescription = ({
     let maxCharacters = maxDescriptionLength;
     for (let index = 0; index < words.length; index++) {
       const word = words[index];
+
+      if (word.length > maxDescriptionLength) {
+        return word.slice(0, maxDescriptionLength);
+      }
+
       maxCharacters -= word.length + 1;
 
       if (maxCharacters < 0) {


### PR DESCRIPTION
## After

<img width="1449" alt="Screen Shot 2021-05-11 at 1 33 31 PM" src="https://user-images.githubusercontent.com/32081352/117881111-b8610200-b25d-11eb-8f10-51c34c6e0859.png">
<img width="1448" alt="Screen Shot 2021-05-11 at 1 33 38 PM" src="https://user-images.githubusercontent.com/32081352/117881113-b8f99880-b25d-11eb-993b-76d16778b6b2.png">

## Before

<img width="1447" alt="Screen Shot 2021-05-11 at 1 34 46 PM" src="https://user-images.githubusercontent.com/32081352/117881119-ba2ac580-b25d-11eb-8d2c-4141c4943313.png">
<img width="1451" alt="Screen Shot 2021-05-11 at 1 34 53 PM" src="https://user-images.githubusercontent.com/32081352/117881122-bac35c00-b25d-11eb-95b1-10cb2343545b.png">
