### PR TITLE
WEB-1075: Fix my creations pagination

### DIFF
--- a/pages/user/[chainAccount].tsx
+++ b/pages/user/[chainAccount].tsx
@@ -91,9 +91,6 @@ const Collection = (): JSX.Element => {
       ...prevCreations,
       ...prefetchedCreations,
     ]);
-    setPrefetchCreationsPageNumber((prevPageNumber) =>
-      prefetchedCreations.length < PAGINATION_LIMIT ? -1 : prevPageNumber + 1
-    );
     setIsLoadingNextPage(true);
     const creations = await getUserCreatedTemplates(
       chainAccount,
@@ -102,6 +99,9 @@ const Collection = (): JSX.Element => {
     );
     setPrefetchedCreations(creations);
     setIsLoadingNextPage(false);
+    setPrefetchCreationsPageNumber((prevPageNumber) =>
+      creations.length < PAGINATION_LIMIT ? -1 : prevPageNumber + 1
+    );
   };
 
   const getUser = async (chainAccount: string): Promise<void> => {
@@ -139,11 +139,14 @@ const Collection = (): JSX.Element => {
           );
           const creations = await getUserCreatedTemplates(
             chainAccount,
-            prefetchCreationsPageNumber,
+            2,
             !isUsersPage
           );
           setRenderedCreations(initialCreations);
           setPrefetchedCreations(creations);
+          setPrefetchCreationsPageNumber(
+            creations.length < PAGINATION_LIMIT ? -1 : 3
+          );
 
           setIsLoading(false);
           setIsInitialPageLoading(false);


### PR DESCRIPTION
PR test:

- Open up localhost with mainnet variables
  - Navigate to http://localhost:3000/user/marlon
  - Load all of Marlon’s creations
  - “Cmd + F” to find “Ghost” NFT - notice how there is only one "Ghost" NFT
- Compare with prod:  http://protonmarket.com/user/marlon
  - Load all of Marlon’s creations
  - “Cmd + F” to find “Ghost” NFT - notice how there are two “Ghost” NFTs

