### PR TITLE
WEB-1076: Fix template video styling

### DIFF
--- a/components/TemplateVideo/TemplateVideo.styled.ts
+++ b/components/TemplateVideo/TemplateVideo.styled.ts
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { FadeInImageContainer } from '../../styles/FadeInImageContainer.styled';
 
 type ImageContainerProps = {
@@ -6,16 +6,11 @@ type ImageContainerProps = {
   isVideo?: boolean;
 };
 
-const SquareContainerCSS = css`
+export const VideoContainer = styled(FadeInImageContainer)<ImageContainerProps>`
   position: relative;
   width: 100%;
-  height: 0;
+  height: 270px;
   padding-bottom: 100%;
-`;
-
-export const VideoContainer = styled(FadeInImageContainer)<ImageContainerProps>`
-  ${SquareContainerCSS};
-  position: relative;
   border-radius: 8px;
   margin-bottom: 24px;
 `;
@@ -44,7 +39,7 @@ export const VideoError = styled.div`
   justify-content: center;
   align-items: center;
   text-align: center;
-  border-radius: 16px;
+  border-radius: 8px;
   padding: 20px;
   font-size: 16px;
   line-height: 24px;


### PR DESCRIPTION
## After

<img width="1199" alt="Screen Shot 2021-05-13 at 9 34 54 AM" src="https://user-images.githubusercontent.com/32081352/118156684-802d0100-b3ce-11eb-82ee-7b4e0bdb4cb3.png">

## Before

<img width="1204" alt="Screen Shot 2021-05-13 at 9 20 59 AM" src="https://user-images.githubusercontent.com/32081352/118156689-828f5b00-b3ce-11eb-806d-d85210fa458d.png">
