### PR TITLE
WEB-979: Move create page state into CreateAssetProvider

### DIFF
--- a/components/ChooseCollection/index.tsx
+++ b/components/ChooseCollection/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, Dispatch, SetStateAction } from 'react';
+import { useState, useEffect, FC, Dispatch, SetStateAction } from 'react';
 import {
   Title,
   SubTitle,
@@ -6,36 +6,27 @@ import {
   ElementTitle,
   ErrorMessage,
 } from '../CreatePageLayout/CreatePageLayout.styled';
-import CollectionsCarousel, {
-  NewCollection,
-  CarouselCollection,
-} from '../CollectionsCarousel';
+import CollectionsCarousel from '../CollectionsCarousel';
+import Button from '../Button';
+import {
+  useAuthContext,
+  useCreateAssetContext,
+  CREATE_PAGE_STATES,
+} from '../../components/Provider';
 import { getAuthorsCollections, Collection } from '../../services/collections';
-import { useAuthContext } from '../../components/Provider';
-import Button from '../../components/Button';
 
-type Props = {
-  collectionsList: Collection[];
-  setSelectedCollection: Dispatch<SetStateAction<CarouselCollection>>;
-  setNewCollection: Dispatch<SetStateAction<NewCollection>>;
-  setIsUncreatedCollectionSelected: Dispatch<SetStateAction<boolean>>;
-  selectedCollection: CarouselCollection;
-  newCollection?: NewCollection;
-  goToCreateTemplate: () => void;
-  setCollectionsList: Dispatch<SetStateAction<Collection[]>>;
-};
-
-const ChooseCollection = ({
-  collectionsList,
-  setSelectedCollection,
-  setNewCollection,
-  setIsUncreatedCollectionSelected,
-  selectedCollection,
-  newCollection,
-  goToCreateTemplate,
-  setCollectionsList,
-}: Props): JSX.Element => {
+const ChooseCollection: FC<{
+  setPageState: Dispatch<SetStateAction<string>>;
+}> = ({ setPageState }) => {
   const { currentUser, isLoadingUser } = useAuthContext();
+  const {
+    setSelectedCollection,
+    setNewCollection,
+    setIsUncreatedCollectionSelected,
+    selectedCollection,
+    newCollection,
+  } = useCreateAssetContext();
+  const [collectionsList, setCollectionsList] = useState<Collection[]>([]);
   const [fetchError, setFetchError] = useState<string>('');
   const [noneSelectedError, setNoneSelectedError] = useState<string>('');
   const [isLoadingCollections, setIsLoadingCollections] = useState<boolean>(
@@ -70,7 +61,7 @@ const ChooseCollection = ({
       );
     } else {
       setNoneSelectedError('');
-      goToCreateTemplate();
+      setPageState(CREATE_PAGE_STATES.CREATE_TEMPLATE);
     }
   };
 

--- a/components/CreatePageLayout/index.tsx
+++ b/components/CreatePageLayout/index.tsx
@@ -1,4 +1,6 @@
+import { FC, useEffect } from 'react';
 import PreviewTemplateCard from '../PreviewTemplateCard';
+import { useCreateAssetContext } from '../Provider';
 import {
   Container,
   Row,
@@ -6,25 +8,42 @@ import {
   RightColumn,
   ElementTitle,
 } from './CreatePageLayout.styled';
-import { CarouselCollection } from '../CollectionsCarousel';
+import { fileReader } from '../../utils';
 
-type Props = {
-  children: JSX.Element;
-  templateVideo: string;
-  templateImage: string;
-  templateName: string;
-  selectedCollection: CarouselCollection;
-  maxSupply: string;
-};
+const CreatePageLayout: FC<{ children: JSX.Element }> = ({ children }) => {
+  const {
+    setTemplateImage,
+    setTemplateVideo,
+    templateUploadedFile,
+    selectedCollection,
+    templateName,
+    templateImage,
+    templateVideo,
+    maxSupply,
+  } = useCreateAssetContext();
 
-const CreatePageLayout = ({
-  children,
-  templateVideo,
-  templateImage,
-  templateName,
-  selectedCollection,
-  maxSupply,
-}: Props): JSX.Element => {
+  useEffect(() => {
+    if (templateUploadedFile && window) {
+      const filetype = templateUploadedFile.type;
+      if (filetype.includes('video')) {
+        const readerSetTemplateVideo = (result) => {
+          setTemplateImage('');
+          setTemplateVideo(result);
+        };
+        fileReader(readerSetTemplateVideo, templateUploadedFile);
+      } else {
+        const readerSetTemplateImage = (result) => {
+          setTemplateVideo('');
+          setTemplateImage(result);
+        };
+        fileReader(readerSetTemplateImage, templateUploadedFile);
+      }
+    } else {
+      setTemplateImage('');
+      setTemplateVideo('');
+    }
+  }, [templateUploadedFile]);
+
   return (
     <Container>
       <Row>

--- a/components/PreviewTemplateCard/index.tsx
+++ b/components/PreviewTemplateCard/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { FC } from 'react';
 import {
   Card,
   Row,
@@ -23,7 +23,7 @@ type Props = {
   hasPlaceholderIcon?: boolean;
 };
 
-const PreviewTemplateCard = ({
+const PreviewTemplateCard: FC<Props> = ({
   collectionName,
   templateName,
   maxSupply,
@@ -32,17 +32,7 @@ const PreviewTemplateCard = ({
   templateVideo,
   templateImage,
   hasPlaceholderIcon,
-}: Props): JSX.Element => {
-  const [templateVideoSrc, setTemplateVideoSrc] = useState<string>(
-    templateVideo
-  );
-  const [templateImgSrc, setTemplateImgSrc] = useState<string>(templateImage);
-
-  useEffect(() => {
-    setTemplateVideoSrc(templateVideo);
-    setTemplateImgSrc(templateImage);
-  }, [templateVideo, templateImage]);
-
+}) => {
   const collectionIcon = hasPlaceholderIcon ? (
     <IconContainer margin="24px 16px 24px 0">
       <PlaceholderIcon />
@@ -64,10 +54,10 @@ const PreviewTemplateCard = ({
         </CollectionNameButton>
       </Row>
       {templateVideo ? (
-        <TemplateVideo src={templateVideoSrc} autoPlay={true} />
+        <TemplateVideo src={templateVideo} autoPlay={true} />
       ) : (
         <TemplateImage
-          templateImgSrc={templateImgSrc}
+          templateImgSrc={templateImage}
           templateName={templateName}
         />
       )}

--- a/components/Provider/CreateAssetProvider.tsx
+++ b/components/Provider/CreateAssetProvider.tsx
@@ -1,26 +1,115 @@
-import { createContext, useState, useContext, useMemo, useEffect } from 'react';
+import {
+  FC,
+  createContext,
+  useState,
+  useContext,
+  useMemo,
+  useEffect,
+  SetStateAction,
+  Dispatch,
+} from 'react';
+import { CarouselCollection, NewCollection } from '../CollectionsCarousel';
 import protonMarketIDB, {
   CachedAssets,
   CachedAsset,
 } from '../../services/indexed-db';
+import ProtonSDK from '../../services/proton';
+import fees, { MintFee } from '../../services/fees';
+import uploadToIPFS from '../../services/upload';
+import {
+  LG_FILE_UPLOAD_TYPES_TEXT,
+  SHORTENED_TOKEN_PRECISION,
+} from '../../utils/constants';
+
+export const CREATE_PAGE_STATES = {
+  CHOOSE_COLLECTION: 'CHOOSE_COLLECTION',
+  CREATE_TEMPLATE: 'CREATE_TEMPLATE',
+  SUCCESS: 'SUCCESS',
+};
+
+const placeholderCollection = {
+  collection_name: '',
+  name: '',
+  img: '',
+};
 
 const emptyCachedAsset = {
   ipfsHash: '',
   file: undefined,
 };
 
-interface CreateAssetContext {
-  cachedNewlyCreatedAssets: CachedAssets;
-  updateCachedNewlyCreatedAssets: (asset: CachedAsset) => void;
-}
+const MintFeeInitial = {
+  specialMintFee: {
+    display: Number('0').toFixed(SHORTENED_TOKEN_PRECISION).toString(),
+    raw: 0,
+  },
+  accountRamFee: {
+    display: Number('0').toFixed(SHORTENED_TOKEN_PRECISION).toString(),
+    raw: 0,
+  },
+  userSpecialMintContractRam: 0,
+  userAccountRam: 0,
+  totalFee: Number('0').toFixed(SHORTENED_TOKEN_PRECISION).toString(),
+};
 
-interface Props {
-  children: JSX.Element | JSX.Element[];
+interface CreateAssetContext {
+  updateCachedNewlyCreatedAssets: (asset: CachedAsset) => Promise<void>;
+  setSelectedCollection: Dispatch<SetStateAction<CarouselCollection>>;
+  setNewCollection: Dispatch<SetStateAction<NewCollection>>;
+  setTemplateName: Dispatch<SetStateAction<string>>;
+  setTemplateDescription: Dispatch<SetStateAction<string>>;
+  setTemplateImage: Dispatch<SetStateAction<string>>;
+  setTemplateVideo: Dispatch<SetStateAction<string>>;
+  setMaxSupply: Dispatch<SetStateAction<string>>;
+  setMintAmount: Dispatch<SetStateAction<string>>;
+  setTemplateUploadedFile: Dispatch<SetStateAction<File | null>>;
+  setUploadedFilePreview: Dispatch<SetStateAction<string>>;
+  setMintFee: Dispatch<SetStateAction<MintFee>>;
+  setIsUncreatedCollectionSelected: Dispatch<SetStateAction<boolean>>;
+  createNft: (author: string) => Promise<string[]>;
+  selectedCollection: CarouselCollection;
+  newCollection: NewCollection;
+  templateName: string;
+  templateDescription: string;
+  templateImage: string;
+  templateVideo: string;
+  maxSupply: string;
+  mintAmount: string;
+  templateUploadedFile: File | null;
+  uploadedFilePreview: string;
+  mintFee: MintFee;
+  isUncreatedCollectionSelected: boolean;
+  cachedNewlyCreatedAssets: CachedAssets;
 }
 
 const CreateAssetContext = createContext<CreateAssetContext>({
+  updateCachedNewlyCreatedAssets: async () => {},
+  setSelectedCollection: () => {},
+  setNewCollection: () => {},
+  setTemplateName: () => {},
+  setTemplateDescription: () => {},
+  setTemplateImage: () => {},
+  setTemplateVideo: () => {},
+  setMaxSupply: () => {},
+  setMintAmount: () => {},
+  setTemplateUploadedFile: () => {},
+  setUploadedFilePreview: () => {},
+  setMintFee: () => {},
+  setIsUncreatedCollectionSelected: () => {},
+  createNft: async () => [],
+  selectedCollection: placeholderCollection,
+  newCollection: undefined,
+  templateName: '',
+  templateDescription: '',
+  templateImage: '',
+  templateVideo: '',
+  maxSupply: '',
+  mintAmount: '',
+  templateUploadedFile: undefined,
+  uploadedFilePreview: '',
+  mintFee: MintFeeInitial,
+  isUncreatedCollectionSelected: false,
   cachedNewlyCreatedAssets: {},
-  updateCachedNewlyCreatedAssets: () => {},
 });
 
 export const useCreateAssetContext = (): CreateAssetContext => {
@@ -28,7 +117,29 @@ export const useCreateAssetContext = (): CreateAssetContext => {
   return context;
 };
 
-export const CreateAssetProvider = ({ children }: Props): JSX.Element => {
+export const CreateAssetProvider: FC<{
+  children: JSX.Element | JSX.Element[];
+}> = ({ children }) => {
+  const [
+    selectedCollection,
+    setSelectedCollection,
+  ] = useState<CarouselCollection>(placeholderCollection);
+  const [newCollection, setNewCollection] = useState<NewCollection>();
+  const [templateName, setTemplateName] = useState<string>('');
+  const [templateDescription, setTemplateDescription] = useState<string>('');
+  const [templateImage, setTemplateImage] = useState<string>('');
+  const [templateVideo, setTemplateVideo] = useState<string>('');
+  const [maxSupply, setMaxSupply] = useState<string>('');
+  const [mintAmount, setMintAmount] = useState<string>('');
+  const [templateUploadedFile, setTemplateUploadedFile] = useState<File | null>(
+    null
+  );
+  const [uploadedFilePreview, setUploadedFilePreview] = useState<string>('');
+  const [mintFee, setMintFee] = useState<MintFee>(MintFeeInitial);
+  const [
+    isUncreatedCollectionSelected,
+    setIsUncreatedCollectionSelected,
+  ] = useState<boolean>(false);
   const [
     cachedNewlyCreatedAssets,
     setCachedNewlyCreatedAssets,
@@ -59,10 +170,120 @@ export const CreateAssetProvider = ({ children }: Props): JSX.Element => {
     }
   }, [assetToAddToIDB]);
 
+  const resetCreatePage = () => {
+    setTemplateUploadedFile(null);
+    setIsUncreatedCollectionSelected(false);
+    setNewCollection(null);
+    setTemplateName('');
+    setTemplateDescription('');
+    setTemplateImage('');
+    setTemplateVideo('');
+    setMaxSupply('');
+    setMintAmount('');
+    setSelectedCollection(placeholderCollection);
+  };
+
+  const getCreateTemplateValidationErrors = (): string[] => {
+    const errors = [];
+
+    if (!templateUploadedFile) {
+      errors.push(`upload a ${LG_FILE_UPLOAD_TYPES_TEXT}`);
+    }
+    if (!templateName) {
+      errors.push('set a name');
+    }
+
+    if (!templateDescription) {
+      errors.push('set a description');
+    }
+
+    if (typeof maxSupply === 'undefined' || isNaN(parseInt(maxSupply))) {
+      errors.push(
+        "set the template's maximum edition size (0 for no maximum edition size)"
+      );
+    }
+
+    if (!mintAmount) {
+      errors.push('set an initial mint amount (minimum 1)');
+    }
+
+    if (maxSupply !== '0' && parseInt(mintAmount) > parseInt(maxSupply)) {
+      errors.push('set an initial mint amount less than the edition size');
+    }
+
+    return errors;
+  };
+
+  const createNft = async (author: string): Promise<string[]> => {
+    const errors = getCreateTemplateValidationErrors();
+    if (errors.length) {
+      return errors;
+    }
+
+    try {
+      const templateIpfsImage = await uploadToIPFS(templateUploadedFile);
+      updateCachedNewlyCreatedAssets({
+        ipfsHash: templateIpfsImage,
+        file: templateUploadedFile,
+      });
+
+      let isVideo = false;
+      if (templateUploadedFile.type.includes('mp4')) {
+        isVideo = true;
+      }
+
+      await fees.refreshRamInfoForUser(author);
+      const finalMintFees = fees.calculateCreateFlowFees({
+        numAssets: parseInt(mintAmount),
+        actor: author,
+      });
+
+      const result = isUncreatedCollectionSelected
+        ? await ProtonSDK.createNft({
+            mintFee: finalMintFees,
+            author,
+            collection_name: newCollection.collection_name,
+            collection_description: newCollection.description,
+            collection_display_name: newCollection.name,
+            collection_image: newCollection.img,
+            collection_market_fee: (
+              parseInt(newCollection.royalties) / 100
+            ).toFixed(6),
+            template_name: templateName,
+            template_description: templateDescription,
+            template_image: isVideo ? null : templateIpfsImage,
+            template_video: isVideo ? templateIpfsImage : null,
+            max_supply: parseInt(maxSupply),
+            initial_mint_amount: parseInt(mintAmount),
+          })
+        : await ProtonSDK.createTemplateAssets({
+            mintFee: finalMintFees,
+            author,
+            collection_name: selectedCollection.collection_name,
+            template_name: templateName,
+            template_image: isVideo ? null : templateIpfsImage,
+            template_video: isVideo ? templateIpfsImage : null,
+            template_description: templateDescription,
+            max_supply: parseInt(maxSupply),
+            initial_mint_amount: parseInt(mintAmount),
+          });
+
+      if (!result.success) {
+        throw new Error();
+      }
+
+      resetCreatePage();
+      return errors;
+    } catch (err) {
+      errors.push(err.message || 'Unable to create the NFT. Please try again.');
+      return errors;
+    }
+  };
+
   const updateCachedNewlyCreatedAssets = async ({
     ipfsHash,
     file,
-  }: CachedAsset) => {
+  }: CachedAsset): Promise<void> => {
     setCachedNewlyCreatedAssets((prevAssets) => ({
       ...prevAssets,
       [ipfsHash]: file,
@@ -73,10 +294,49 @@ export const CreateAssetProvider = ({ children }: Props): JSX.Element => {
 
   const value = useMemo<CreateAssetContext>(
     () => ({
+      setSelectedCollection,
+      setNewCollection,
+      setTemplateName,
+      setTemplateDescription,
+      setTemplateImage,
+      setTemplateVideo,
+      setMaxSupply,
+      setMintAmount,
+      setTemplateUploadedFile,
+      setUploadedFilePreview,
+      setMintFee,
+      setIsUncreatedCollectionSelected,
+      createNft,
       updateCachedNewlyCreatedAssets,
+      selectedCollection,
+      newCollection,
+      templateName,
+      templateDescription,
+      templateImage,
+      templateVideo,
+      maxSupply,
+      mintAmount,
+      templateUploadedFile,
+      uploadedFilePreview,
+      mintFee,
+      isUncreatedCollectionSelected,
       cachedNewlyCreatedAssets,
     }),
-    [cachedNewlyCreatedAssets]
+    [
+      selectedCollection,
+      newCollection,
+      templateName,
+      templateDescription,
+      templateImage,
+      templateVideo,
+      maxSupply,
+      mintAmount,
+      templateUploadedFile,
+      uploadedFilePreview,
+      mintFee,
+      isUncreatedCollectionSelected,
+      cachedNewlyCreatedAssets,
+    ]
   );
 
   return (

--- a/components/Provider/index.ts
+++ b/components/Provider/index.ts
@@ -1,5 +1,6 @@
 export { useAuthContext, AuthProvider } from './AuthProvider';
 export {
+  CREATE_PAGE_STATES,
   useCreateAssetContext,
   CreateAssetProvider,
 } from './CreateAssetProvider';

--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -1,103 +1,23 @@
 /* eslint-disable jsx-a11y/media-has-caption */
-import { useState, useEffect } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import PageLayout from '../components/PageLayout';
 import MobileCreatePagePlaceholder from '../components/MobileCreatePagePlaceholder';
-import { useAuthContext, useCreateAssetContext } from '../components/Provider';
-import { Collection } from '../services/collections';
-import ProtonSDK from '../services/proton';
-import uploadToIPFS from '../services/upload';
-import { useNavigatorUserAgent } from '../hooks';
-import { fileReader } from '../utils';
-import {
-  CarouselCollection,
-  NewCollection,
-} from '../components/CollectionsCarousel';
 import NftCreateSuccess from '../components/NftCreateSuccess';
 import CreatePageLayout from '../components/CreatePageLayout';
 import ChooseCollection from '../components/ChooseCollection';
 import CreateTemplate from '../components/CreateTemplate';
-import { SHORTENED_TOKEN_PRECISION } from '../utils/constants';
-import fees, { MintFee } from '../services/fees';
+import { useAuthContext, CREATE_PAGE_STATES } from '../components/Provider';
+import fees from '../services/fees';
+import { useNavigatorUserAgent } from '../hooks';
 
-const MintFeeInitial = {
-  specialMintFee: {
-    display: Number('0').toFixed(SHORTENED_TOKEN_PRECISION).toString(),
-    raw: 0,
-  },
-  accountRamFee: {
-    display: Number('0').toFixed(SHORTENED_TOKEN_PRECISION).toString(),
-    raw: 0,
-  },
-  userSpecialMintContractRam: 0,
-  userAccountRam: 0,
-  totalFee: Number('0').toFixed(SHORTENED_TOKEN_PRECISION).toString(),
-};
-
-export const CREATE_PAGE_STATES = {
-  CHOOSE_COLLECTION: 'CHOOSE_COLLECTION',
-  CREATE_TEMPLATE: 'CREATE_TEMPLATE',
-  SUCCESS: 'SUCCESS',
-};
-
-const placeholderCollection = {
-  collection_name: '',
-  name: '',
-  img: '',
-};
-
-const Create = (): JSX.Element => {
-  const { updateCachedNewlyCreatedAssets } = useCreateAssetContext();
+const Create: FC = () => {
   const router = useRouter();
   const { currentUser, isLoadingUser } = useAuthContext();
   const { isDesktop } = useNavigatorUserAgent();
-  const [
-    selectedCollection,
-    setSelectedCollection,
-  ] = useState<CarouselCollection>(placeholderCollection);
-  const [newCollection, setNewCollection] = useState<NewCollection>();
-  const [templateName, setTemplateName] = useState<string>('');
-  const [templateDescription, setTemplateDescription] = useState<string>('');
-  const [templateImage, setTemplateImage] = useState<string>('');
-  const [templateVideo, setTemplateVideo] = useState<string>('');
-  const [maxSupply, setMaxSupply] = useState<string>('');
-  const [mintAmount, setMintAmount] = useState<string>('');
-  const [templateUploadedFile, setTemplateUploadedFile] = useState<File | null>(
-    null
-  );
-  const [uploadedFilePreview, setUploadedFilePreview] = useState<string>('');
-  const [collectionsList, setCollectionsList] = useState<Collection[]>([]);
-  const [createNftError, setCreateNftError] = useState<string>('');
-  const [mintFee, setMintFee] = useState<MintFee>(MintFeeInitial);
-  const [
-    isUncreatedCollectionSelected,
-    setIsUncreatedCollectionSelected,
-  ] = useState<boolean>(false);
   const [pageState, setPageState] = useState<string>(
     CREATE_PAGE_STATES.CHOOSE_COLLECTION
   );
-
-  useEffect(() => {
-    if (templateUploadedFile && window) {
-      const filetype = templateUploadedFile.type;
-      if (filetype.includes('video')) {
-        const readerSetTemplateVideo = (result) => {
-          setTemplateImage('');
-          setTemplateVideo(result);
-        };
-        fileReader(readerSetTemplateVideo, templateUploadedFile);
-      } else {
-        const readerSetTemplateImage = (result) => {
-          setTemplateVideo('');
-          setTemplateImage(result);
-        };
-        fileReader(readerSetTemplateImage, templateUploadedFile);
-      }
-    } else {
-      setTemplateImage('');
-      setTemplateVideo('');
-    }
-  }, [templateUploadedFile]);
 
   useEffect(() => {
     if (!currentUser && !isLoadingUser) {
@@ -109,84 +29,6 @@ const Create = (): JSX.Element => {
       }
     })();
   }, [currentUser, isLoadingUser]);
-
-  const createNft = async () => {
-    setCreateNftError('');
-
-    try {
-      const templateIpfsImage = await uploadToIPFS(templateUploadedFile);
-      updateCachedNewlyCreatedAssets({
-        ipfsHash: templateIpfsImage,
-        file: templateUploadedFile,
-      });
-
-      let isVideo = false;
-      if (templateUploadedFile.type.includes('mp4')) {
-        isVideo = true;
-      }
-
-      await fees.refreshRamInfoForUser(currentUser.actor);
-      const finalMintFees = fees.calculateCreateFlowFees({
-        numAssets: parseInt(mintAmount),
-        actor: currentUser ? currentUser.actor : '',
-      });
-
-      const result = isUncreatedCollectionSelected
-        ? await ProtonSDK.createNft({
-            mintFee: finalMintFees,
-            author: currentUser.actor,
-            collection_name: newCollection.collection_name,
-            collection_description: newCollection.description,
-            collection_display_name: newCollection.name,
-            collection_image: newCollection.img,
-            collection_market_fee: (
-              parseInt(newCollection.royalties) / 100
-            ).toFixed(6),
-            template_name: templateName,
-            template_description: templateDescription,
-            template_image: isVideo ? null : templateIpfsImage,
-            template_video: isVideo ? templateIpfsImage : null,
-            max_supply: parseInt(maxSupply),
-            initial_mint_amount: parseInt(mintAmount),
-          })
-        : await ProtonSDK.createTemplateAssets({
-            mintFee: finalMintFees,
-            author: currentUser.actor,
-            collection_name: selectedCollection.collection_name,
-            template_name: templateName,
-            template_image: isVideo ? null : templateIpfsImage,
-            template_video: isVideo ? templateIpfsImage : null,
-            template_description: templateDescription,
-            max_supply: parseInt(maxSupply),
-            initial_mint_amount: parseInt(mintAmount),
-          });
-
-      if (!result.success) {
-        throw new Error();
-      }
-
-      setPageState(CREATE_PAGE_STATES.SUCCESS);
-      resetCreatePage();
-    } catch (err) {
-      setCreateNftError('Unable to create the NFT. Please try again.');
-    }
-  };
-
-  const resetCreatePage = () => {
-    // Needed to clean up page in case user comes back to Create from success screen
-    setTemplateUploadedFile(null);
-    setCollectionsList([]);
-    setCreateNftError('');
-    setIsUncreatedCollectionSelected(false);
-    setNewCollection(null);
-    setTemplateName('');
-    setTemplateDescription('');
-    setTemplateImage('');
-    setTemplateVideo('');
-    setMaxSupply('');
-    setMintAmount('');
-    setSelectedCollection(placeholderCollection);
-  };
 
   const getContent = () => {
     if (!currentUser) {
@@ -208,56 +50,14 @@ const Create = (): JSX.Element => {
         );
       case CREATE_PAGE_STATES.CREATE_TEMPLATE:
         return (
-          <CreatePageLayout
-            templateVideo={templateVideo}
-            templateImage={templateImage}
-            templateName={templateName}
-            selectedCollection={selectedCollection}
-            maxSupply={maxSupply}>
-            <CreateTemplate
-              setTemplateUploadedFile={setTemplateUploadedFile}
-              templateUploadedFile={templateUploadedFile}
-              templateName={templateName}
-              setTemplateName={setTemplateName}
-              templateDescription={templateDescription}
-              setTemplateDescription={setTemplateDescription}
-              maxSupply={maxSupply}
-              setMaxSupply={setMaxSupply}
-              setPageState={setPageState}
-              uploadedFilePreview={uploadedFilePreview}
-              setUploadedFilePreview={setUploadedFilePreview}
-              mintAmount={mintAmount}
-              setMintFee={setMintFee}
-              mintFee={mintFee}
-              setMintAmount={setMintAmount}
-              createNft={createNft}
-              createNftError={createNftError}
-              setCreateNftError={setCreateNftError}
-            />
+          <CreatePageLayout>
+            <CreateTemplate setPageState={setPageState} />
           </CreatePageLayout>
         );
       default:
         return (
-          <CreatePageLayout
-            templateVideo={templateVideo}
-            templateImage={templateImage}
-            templateName={templateName}
-            selectedCollection={selectedCollection}
-            maxSupply={maxSupply}>
-            <ChooseCollection
-              collectionsList={collectionsList}
-              selectedCollection={selectedCollection}
-              newCollection={newCollection}
-              setSelectedCollection={setSelectedCollection}
-              setNewCollection={setNewCollection}
-              setIsUncreatedCollectionSelected={
-                setIsUncreatedCollectionSelected
-              }
-              goToCreateTemplate={() =>
-                setPageState(CREATE_PAGE_STATES.CREATE_TEMPLATE)
-              }
-              setCollectionsList={setCollectionsList}
-            />
+          <CreatePageLayout>
+            <ChooseCollection setPageState={setPageState} />
           </CreatePageLayout>
         );
     }


### PR DESCRIPTION
In addition to moving the create page state into CreateAssetProvider, this PR also takes care of the following small bugs:
- User is unable to mint `1` asset when setting their max supply to `0`
- User is unable to use the enter key to create an NFT instead of clicking the create NFT button