### PR TITLE
Fix some async calls for WebAuth

### DIFF
--- a/components/Modal/CreateSaleModal.tsx
+++ b/components/Modal/CreateSaleModal.tsx
@@ -146,10 +146,13 @@ export const CreateSaleModal: FC = () => {
     raw: null,
   });
 
+  useEffect(() => {
+    fees.refreshRamInfoForUser(currentUser.actor);
+  });
+
   const createOneSale = async () => {
     try {
       const formattedAmount = parseFloat(amount).toFixed(TOKEN_PRECISION);
-      await fees.refreshRamInfoForUser(currentUser.actor);
       const finalFee = fees.calculateFee({
         numAssets: 1,
         actor: currentUser ? currentUser.actor : '',
@@ -203,10 +206,13 @@ export const CreateMultipleSalesModal: FC = () => {
   const numSales = assetIds.length;
   const maxNumSales = 100;
 
+  useEffect(() => {
+    fees.refreshRamInfoForUser(currentUser.actor);
+  });
+
   const createMultipleSales = async () => {
     try {
       const formattedAmount = parseFloat(amount).toFixed(TOKEN_PRECISION);
-      await fees.refreshRamInfoForUser(currentUser.actor);
       const finalFee = fees.calculateFee({
         numAssets: numSales,
         actor: currentUser ? currentUser.actor : '',

--- a/components/Modal/TransferModal.tsx
+++ b/components/Modal/TransferModal.tsx
@@ -41,12 +41,12 @@ export const TransferModal = (): JSX.Element => {
         return;
       }
 
-      const user = await proton.getUserByChainAccount(recipient);
+      // const user = await proton.getUserByChainAccount(recipient);
 
-      if (!user) {
-        setError('Invalid user. Please try again.');
-        return;
-      }
+      // if (!user) {
+      //   setError('Invalid user. Please try again.');
+      //   return;
+      // }
 
       const res = await ProtonSDK.transfer({
         sender: currentUser ? currentUser.actor : '',

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@bloks/link": "^3.2.3-15",
     "@bloks/utils": "^25.0.0",
-    "@bloks/web-sdk": "^2.7.23-43",
+    "@bloks/web-sdk": "^2.7.23-44",
     "@google/model-viewer": "^1.6.0",
     "@netlify/plugin-nextjs": "3.2.2",
     "@proton/js": "^22.0.64",

--- a/services/proton.ts
+++ b/services/proton.ts
@@ -1,6 +1,5 @@
 import { ConnectWallet, ProtonWebLink } from '@bloks/web-sdk';
 import { ChainId, Link, LinkSession } from '@bloks/link';
-import logoUrl from '../public/logo.svg';
 import proton from './proton-rpc';
 import { DEFAULT_SCHEMA, TOKEN_PRECISION } from '../utils/constants';
 import fees, { MintFee } from '../services/fees';
@@ -220,11 +219,6 @@ class ProtonSDK {
 
   logout = async () => {
     await this.link.removeSession(this.requestAccount, this.auth, this.chainId);
-    this.auth = null;
-    this.link = null;
-    this.session = null;
-    this.accountData = null;
-    this.chainId = null;
   };
 
   restoreSession = async () => {
@@ -467,10 +461,7 @@ class ProtonSDK {
    * @return {Action}                                     Returns an array of conditional ram actions.
    */
 
-  generateRamActions = async ({
-    author,
-    mintFee,
-  }: GenerateRamActions): Promise<Action[]> => {
+  generateRamActions = ({ author, mintFee }: GenerateRamActions): Action[] => {
     const hasInitializedStorage = mintFee.userSpecialMintContractRam !== -1;
     const hasEnoughAccountRam = mintFee.accountRamFee.raw === 0;
     const hasEnoughContractRam = mintFee.specialMintFee.raw === 0;
@@ -570,7 +561,7 @@ class ProtonSDK {
   }: CreateNftOptions): Promise<Response> => {
     const collection_name_or_author = collection_name || author;
 
-    const ramActions = await this.generateRamActions({
+    const ramActions = this.generateRamActions({
       author,
       mintFee,
     });
@@ -701,7 +692,6 @@ class ProtonSDK {
     ];
 
     try {
-      console.log('createNft, session? ', this.session);
       if (!this.session || !this.auth) {
         throw new Error(
           'Unable to create and mint a collection, schema, template, and assets without logging in.'
@@ -904,7 +894,7 @@ class ProtonSDK {
     max_supply,
     initial_mint_amount,
   }: CreateTemplateAssetsOptions): Promise<Response> => {
-    const ramActions = await this.generateRamActions({
+    const ramActions = this.generateRamActions({
       author,
       mintFee,
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,10 +1714,10 @@
     long "^4.0.0"
     qs "^6.9.0"
 
-"@bloks/web-sdk@^2.7.23-43":
-  version "2.7.23-43"
-  resolved "https://registry.yarnpkg.com/@bloks/web-sdk/-/web-sdk-2.7.23-43.tgz#d3ecce9e7ae0ca9a55bc24b2530f2dcd064232a3"
-  integrity sha512-62qv0GXznBeNlVZv6shKynnkC+12WQP4nTrI06tatlmRpk7Pg3uNwzZM4fzjoeVE5qPjR7YUENsvvY88EUpLvg==
+"@bloks/web-sdk@^2.7.23-44":
+  version "2.7.23-44"
+  resolved "https://registry.yarnpkg.com/@bloks/web-sdk/-/web-sdk-2.7.23-44.tgz#45fe15135695dc269de23fd62f58c0d51cd6e384"
+  integrity sha512-tpQcThKrAOIhFXEPDnBoXm2CXuE4jYN6vSN4xS2AuGBcmze8DW+zl7qay7J5kSoTUvVTg44kfz4xZukGZWL5ZA==
   dependencies:
     "@bloks/browser-transport" "^3.2.1-12"
     "@bloks/link" "^3.2.3-15"


### PR DESCRIPTION
```
createNft
createTemplateAssets
updateCollection
```

These 3 functions need to be refactored such so that these functions and the parent functions that calls them do not execute any async calls before .transact()

For the uploadToIPFS stuff that execute async, I say lets just upload to IPFS when the image changes in useEffects (without waiting for signature)

For the async refreshRamInfoForUser, maybe load that every 15 seconds user is on page? or on initial load, etc
