### PR TITLE
fix: fall back to img attribute when image is missing

### DIFF
--- a/components/SearchInputResultsList/index.tsx
+++ b/components/SearchInputResultsList/index.tsx
@@ -137,7 +137,7 @@ const SearchInputResultsList = ({
             name,
             template_id,
             collection: { collection_name },
-            immutable_data: { image, video },
+            immutable_data: { image, img, video },
           },
           i
         ) => {
@@ -154,7 +154,7 @@ const SearchInputResultsList = ({
               key={name}>
               <TemplateIcon
                 name={name}
-                image={image}
+                image={image || img}
                 video={video}
                 margin="0 12px 0 0"
               />

--- a/services/templates.ts
+++ b/services/templates.ts
@@ -19,6 +19,7 @@ export type Schema = {
 type ImmutableData = {
   name: string;
   image?: string;
+  img?: string;
   series: number;
   desc: string;
   video?: string;
@@ -83,6 +84,17 @@ type formatTemplatesWithLowPriceAndAssetCountProps = {
  * @return {Template[]}              Returns array of templates, most likely will only return one item in the array
  */
 
+/**
+ * Normalize immutable_data: fall back to 'img' if 'image' is missing.
+ * Some collections use 'img' instead of the standard 'image' attribute.
+ */
+const normalizeTemplate = (template: Template): Template => {
+  if (template.immutable_data && !template.immutable_data.image && template.immutable_data.img) {
+    template.immutable_data.image = template.immutable_data.img;
+  }
+  return template;
+};
+
 export const getTemplateDetails = async (
   collectionName: string,
   templateId: string
@@ -117,10 +129,10 @@ export const getTemplateDetails = async (
           )} ${lowestPriceSale.listing_symbol}`
         : '';
 
-    return {
+    return normalizeTemplate({
       ...templatesResponse.data[0],
       lowestPrice,
-    };
+    });
   } catch (e) {
     throw new Error(e);
   }
@@ -159,7 +171,7 @@ export const getTemplatesByCollection = async ({
       throw new Error(errorMessage as string);
     }
 
-    return templatesResponse.data;
+    return templatesResponse.data.map(normalizeTemplate);
   } catch (e) {
     throw new Error(e);
   }
@@ -206,7 +218,7 @@ export const getAllTemplatesByCollection = async ({
         hasResults = false;
       }
 
-      templates = templates.concat(templatesResponse.data);
+      templates = templates.concat(templatesResponse.data.map(normalizeTemplate));
       page += 1;
     }
 
@@ -496,7 +508,7 @@ export const getTemplatesFromTemplateIds = async (
       }
 
       page += 1;
-      templates = templates.concat(templatesResponse.data);
+      templates = templates.concat(templatesResponse.data.map(normalizeTemplate));
     } catch (e) {
       throw new Error(e);
     }
@@ -534,7 +546,7 @@ export const getPaginatedCreationsByCreator = async ({
       throw new Error((templatesResponse.message as unknown) as string);
     }
 
-    return templatesResponse.data;
+    return templatesResponse.data.map(normalizeTemplate);
   } catch (e) {
     throw new Error(e);
   }
@@ -576,7 +588,7 @@ export const getAllCreationsByCreator = async ({
         hasResults = false;
       }
 
-      templates = templates.concat(templatesResponse.data);
+      templates = templates.concat(templatesResponse.data.map(normalizeTemplate));
       page += 1;
     }
 


### PR DESCRIPTION
## Summary

- Some NFT collections use `img` instead of the standard `image` attribute for IPFS CIDs in their schema
- This caused the marketplace to show blank images with `GET /ipfs/undefined` errors
- Added `normalizeTemplate()` in `services/templates.ts` that maps `img` → `image` at the data layer
- Applied to all template fetch functions so every component works without changes
- Also added `img` fallback in `SearchInputResultsList` for search results

## Test plan

- [ ] Verify collections using `image` attribute still display correctly
- [ ] Verify collections using `img` attribute now display correctly (e.g. `charlieart12` on testnet)
- [ ] Test search results show images for both attribute names

🤖 Generated with [Claude Code](https://claude.com/claude-code)